### PR TITLE
dut-setup: fix typo and add note

### DIFF
--- a/doc/sphinx/source/dut-setup.txt
+++ b/doc/sphinx/source/dut-setup.txt
@@ -11,6 +11,9 @@ First of all, you need to connect to the MuxPi::
 
    $ ssh root@192.168.0.2
 
+.. note::
+   The ip address varies on your network, an easy solution would be to create a local network 
+   with an extra router and running nmap on it.  
 
 **************************
 Set up DHCP server on eth1
@@ -82,14 +85,14 @@ Connect using UART
    .. note::
 
       You need to adjust setting in the command above to fit your UART
-      connection
-
+      connection. That can be the device file or the baud rate.
+   
    .. warning:: This setting is temporary.
 
 #. Connect to the device using your tool of choice::
 
       # screen /dev/ttyS1 115200
-      # minicom -b 115200 -D /dev/ttyUSB0
+      # minicom -b 115200 -D /dev/ttyS1
 
    .. note:: Adjust the baud rate accordingly.
 

--- a/doc/sphinx/source/fota.txt
+++ b/doc/sphinx/source/fota.txt
@@ -1,0 +1,44 @@
+######################
+FOTA software of MuxPi
+######################
+
+This manual presents the main functionalities of fota.
+
+The SD-mux together with NanoPi Neo have two microSD card slots. The slot on
+the NanoPi Neo is used to boot MuxPi up and install software such as fota or
+stm. When using FOTA, the card slot on the SD-mux must be used.
+
+Find the correct device by running ``lsblk``
+
+**********
+Fota usage
+**********
+
+Overall, the idea of FOTA is to flash images to drives. Fota requires three
+arguments. The device to flash (e.g /dev/sda), a json file, and the path to the
+image compressed in ``tar.gz``. Optionally, you could also add the md5sum of
+the tarball.
+
+Example:
+
+fota -card /dev/sda -map map.json image.tar.gz
+=========
+JSON file
+=========
+
+The json file requires the name of the image, and the partition of the device::
+	{"boot.img": "1", "rootfs.img": "2"}
+
+This will write boot.img to /dev/sdX1 and the rootfs.img to /dev/sdX2. This is
+useful when you don't need to flash both partitions.
+
+.. Note ::
+	Depending on the image, it might require some modification in order to be flashed. 
+
+====================
+microSD-card adapter
+====================
+
+It is important to note that the length of the microSD-card adapter can play a
+big role. For raspberrypi3, the length of the cable is recommended to be from 1
+to 5cm. 

--- a/doc/sphinx/source/index.txt
+++ b/doc/sphinx/source/index.txt
@@ -20,8 +20,9 @@ whole platform for specific target devices.
    armbian
    install-sw
    dut-setup
+   fota.txt
 
-Indices and tables
+   Indices and tables
 ==================
 
 * :ref:`genindex`


### PR DESCRIPTION
The serial communication device is always set to be /dev/ttyS2.
A small note when initially connecting with MuxPi
A new file which describes fota. 

Signed-off-by: Fisnik Hajredini <fisnikhajredini@gmail.com>